### PR TITLE
Added part of the google doc documentation to the readme, with emp…

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,238 @@ The bot currently features 49 commands.
 
 A temporary manual on what the commands do and how to use the bot is available here: https://docs.google.com/document/d/1anSFPfBuMPzKJ7JwejBnpB7KMsiw-Lrk50LMfNRJt6Q/edit?usp=sharing
 
+## Quick Start
+By default, the role that is able to run management related commands is set to the highest role in your server hierarchy. This can be changed via
+```bash
+/config_roles
+```
+After selecting this command you will be displayed a list of options for roles you want to select. 
+Pick the role you want either by selection or typing the name, this feature works with most commands.
+
+<span style="color: red;"><b>IMPORTANT:</span> THE @CC-117 ROLE MUST BE ABOVE ANY OF THESE ROLES IN YOUR SERVER HIERARCHY IN ORDER FOR THE BOT TO APPLY THEM TO MEMBERS.</b></span>
+
+
+## Roles
+```bash
+Admin - Role required to run various config commands. Any role above this will also be able to run. Commands marked with '*' require Admin role to run. 
+Owner
+Chief
+Strategist
+Captain
+Recruiter
+Recruit
+Ally Owner
+Ally
+Champion
+Hero
+VIP+
+VIP
+Veteran
+Verified
+Unverified
+Member of 
+Administrator - member has an administrator role in Wynncraft
+Moderator
+Content Team
+Giveaway
+```
+
+
+## Config Commands
+```bash
+/config_levelroles*
+```
+Works similar to the above command. This command is used for applying roles based on the highest combat level on a players account. You can set up 10. Currently, you will need to order them from highest to lowest and remember the order otherwise it could cause issues for other features.
+
+To use: Run the command and selet the optoins and pick the role. The options are named "Level Role One", "Level Role Two" etc. So make one level 106, two 106, three 100, etc.
+
+```bash
+/config_levels*
+```
+This command is paired with the above. Use this to set what level is required to get that role. Unlike the previous commands, you won't be presented with an option for the value input, after you've selected the "Level One Level" option you simply have to type in the number you want for that level role, say for example 106.
+
+
+```bash
+/config_classroles*
+```
+Roles for letting users pick their favourite class and archetype. 
+
+```bash
+/config_warroles*
+```
+
+```bash
+/config_channels*
+```
+
+```bash
+/config_promotions*
+```
+
+```bash
+/config_<rank>promotions*
+```
+
+```bash
+/config_features*
+```
+
+```bash
+/config_values*
+```
+<b>That's it for the config commands!</b>
+
+## Management Commands
+```bash
+/setguild*
+```
+Sets the guild you want to represent. Enter the prefix or full guid name.
+
+```bash
+/addally*
+```
+Add guilds you want to classify as allies, has no effect on Wynncraft.
+
+```bash
+/removeally* 
+```
+Remove guild(s) you have set as allies
+
+```bash
+/allies*
+```
+Shows a list of allied guilds
+
+```bash
+/trackguild*
+```
+Adds a guild to your personal tracked list
+
+```bash
+/trackedguilds*
+```
+Lists tracked guilds
+```bash
+/untrackguild*
+```
+Untracks a guild
+Displays all the guilds that have been tracked in your server
+
+```bash
+/adddemotionexception*
+```
+```bash
+/addinactivityexception*
+```
+
+```bash
+/addpromotionexception*
+```
+
+```bash
+/removeddemotoinexception*
+```
+
+```bash
+/removeinactivityexception*
+```
+
+```bash
+/removepromotionexception*
+```
+
+```bash
+/createclassmessage*
+```
+
+```bash
+/creategiveawaymessage*
+```
+
+```bash
+/createwarmessage*
+```
+
+```bash
+/help
+```
+
+```bash
+/updateguild
+```
+
+```bash
+/updateplayer
+```
+
+```bash
+/updateranks*
+```
+
+```bash
+/viewconfig*
+```
+
+## More commands 
+Commands for the average user
+
+```bash
+/verify
+```
+
+```bash
+/unverify
+```
+
+```bash
+/activehours
+```
+
+```bash
+/checkfordemotions
+```
+
+```bash
+/checkforpromotions
+```
+
+```bash
+/demotionexceptions*
+```
+
+```bash
+/promotionexceptions*
+```
+
+```bash
+/inactivityexceptions*
+```
+
+```bash
+/sus*
+```
+
+```bash
+/verified*
+```
+
+```bash
+/worldactivity
+```
+
+```bash
+/trackedguilds
+```
+
+```bash
+/online
+```
+
+```bash
+/lastlogins
+```
+
+Please refer to the linked google doc for a closer look at command functions
 ## Database
 
 The database used for the bot contains 2 tables by default, guilds and players. However "primary" guilds also have their own table, these are guilds that a server has chosen to represent.


### PR DESCRIPTION
…hasis on making documentation more concise and simple for newbies to figure out

I added at least all of the command names to the readme, and split them into little sections based on quick start guide, config, admin, and general user commands. 
I thought about copying more of the descriptions of each command from the doc, but I think a lot of the descriptions are long and wordy, and I'm not the most qualified to completely paraphrase them. Also the doc is just really long haha.

I think overall the documentation would benefit by being made more concise and being put in the readme, or other .md file.

Cheers!